### PR TITLE
Remove $afterWhere.

### DIFF
--- a/src/plugins/Db.php
+++ b/src/plugins/Db.php
@@ -105,7 +105,7 @@ class Db extends PDO
      */
     public function selectValue($tableName, $column, $where = null)
     {
-        $stmt = $this->executeSelect($tableName, $column, $where, $afterWhere);
+        $stmt = $this->executeSelect($tableName, $column, $where);
         return $stmt->fetchColumn();
     }
     


### PR DESCRIPTION
Error rised when we use $this[db']->count() :
Notice: Undefined variable: afterWhere in .\atomik\src\plugins\Db.php on line 108
