### PR TITLE
Add default driver_options

### DIFF
--- a/src/plugins/Db.php
+++ b/src/plugins/Db.php
@@ -31,11 +31,16 @@ class Db extends PDO
             
             // password
             'password'          => '',
+            
+            // driver options
+            'driver_options'    => array( 
+                PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8' 
+            ),
 
         ), $config);
 
         self::$config = &$config;
-        self::$instance = new Db($config['dsn'], $config['username'], $config['password']);
+        self::$instance = new Db($config['dsn'], $config['username'], $config['password'], $config['driver_options']);
         Atomik::set('db', self::$instance);
     }
 


### PR DESCRIPTION
Add a default value for driver_options, and allow user to override this value.
This default value is the one preconized by php.net to avoid charset issues (http://php.net/manual/en/ref.pdo-mysql.connection.php)
