### PR TITLE
Fix issue with routes starting by a parameter.

### DIFF
--- a/src/Atomik.php
+++ b/src/Atomik.php
@@ -531,7 +531,7 @@ final class Atomik implements ArrayAccess
         
             if ($pattern{0} !== '#') {
                 $pattern = trim(str_replace('/*/', '/(.+)/', $pattern), '/');
-                if (preg_match_all('#(([/.]):([a-z_0-9]+))#i', $pattern, $matches)) {
+                if (preg_match_all('#((^|[/.]):([a-z_0-9]+))#i', $pattern, $matches)) {
                     for ($i = 0, $c = count($matches[0]); $i < $c; $i++) {
                         $param = $matches[3][$i];
                         $paramRegexp = preg_quote($matches[2][$i], '#') . "(?P<$param>[^/]+)";


### PR DESCRIPTION
Example :

```
Atomik::set(array(
    'app' => array(
        'routes' => array(
            ':year/archives' => array('action' => 'archives/index')
        )
    )
);
```

For `http://domain.tld/2014/archives` uri, action will be `2014/archives` instead of `archives/index`, as the `:year` parameter is not caught.
