### PR TITLE
Allow multiples values for a single key in _buildWhere()

### DIFF
--- a/src/plugins/Db.php
+++ b/src/plugins/Db.php
@@ -199,7 +199,6 @@ class Db extends PDO
      */
     protected function _buildWhere($where)
     {
-        var_dump($where);
         if (empty($where)) {
             return array('', array());
         }
@@ -214,7 +213,7 @@ class Db extends PDO
                 $values = array_merge($values, $value);
             } else {
                 $output .= $key . ' = ? AND ';
-                array_push($values, $value);
+                $values[] = $value;
             }
         }
         return array(


### PR DESCRIPTION
Allow user to set multiples values for a single key.
# Examples : 

```
$posts = $this['db']->select('articles', '*', array('year' => array(2014, 2015)));
```
# Tests : 

Empty string : `_buildWhere()` 

```
array(2) {
  [0]=>
  string(0) ""
  [1]=>
  array(0) {
  }
}
```

No parameters : `_buildWhere('year = 2014')` 

```
array(2) {
  [0]=>
  string(17) "WHERE year = 2014"
  [1]=>
  array(0) {
  }
}
```

Bind an integer : `_buildWhere(array('year' => 2014))` 

```
array(2) {
  [0]=>
  string(14) "WHERE year = ?"
  [1]=>
  array(1) {
    [0]=>
    int(2014)
  }
}
```

Bind a string : `_buildWhere(array('year' => '2014'))` 

```
array(2) {
  [0]=>
  string(14) "WHERE year = ?"
  [1]=>
  array(1) {
    [0]=>
    string(4) "2014"
  }
}
```

Bind an array : `_buildWhere(array('year' => array('2014', '2015')))` 

```
array(2) {
  [0]=>
  string(19) "WHERE year IN(?, ?)"
  [1]=>
  array(2) {
    [0]=>
    string(4) "2014"
    [1]=>
    string(4) "2015"
  }
}
```

Bind a string plus an array : `_buildWhere(array('year' => '2014', 'month' => array('jan', 'fev')))` 

```
array(2) {
  [0]=>
  string(33) "WHERE year = ? AND month IN(?, ?)"
  [1]=>
  array(3) {
    [0]=>
    string(4) "2014"
    [1]=>
    string(3) "jan"
    [2]=>
    string(3) "fev"
  }
}
```

Bind an array plus a string : `_buildWhere(array('year' => array('2014', '2015'), 'month' => 'jan'))` 

```
array(2) {
  [0]=>
  string(33) "WHERE year IN(?, ?) AND month = ?"
  [1]=>
  array(3) {
    [0]=>
    string(4) "2014"
    [1]=>
    string(4) "2015"
    [2]=>
    string(3) "jan"
  }
}
```

Bind two arrays : `_buildWhere(array('year' => array('2014', '2015'), 'month' => array('jan', 'fev')))` 

```
array(2) {
  [0]=>
  string(38) "WHERE year IN(?, ?) AND month IN(?, ?)"
  [1]=>
  array(4) {
    [0]=>
    string(4) "2014"
    [1]=>
    string(4) "2015"
    [2]=>
    string(3) "jan"
    [3]=>
    string(3) "fev"
  }
}
```
